### PR TITLE
Always send no automated responses message

### DIFF
--- a/bot_modules/error_analyse/index.js
+++ b/bot_modules/error_analyse/index.js
@@ -167,11 +167,7 @@ function parseLog (msg, contents) {
 
   // If we have no fields set the description acordingly
   if (embed.fields.length <= 0) {
-    if (geyserException) {
-      embed.setDescription('We don\'t currently have automated responses for the detected errors!')
-    } else {
-      embed.setDescription('The errors you have are unlikely to be Geyser related or caused!')
-    }
+    embed.setDescription('We don\'t currently have automated responses for the detected errors!')
   }
 
   msg.channel.send(embed)


### PR DESCRIPTION
Sometimes errors are Geyser-related, so let's not make it sound like Geyser-related errors are not important.