### PR TITLE
Add warning about Citizens Discord

### DIFF
--- a/bot_modules/dump_analyse/index.js
+++ b/bot_modules/dump_analyse/index.js
@@ -258,5 +258,20 @@ exports.init = (client) => {
     }
 
     msg.channel.send({ embed })
+
+    // Citizens
+    if (response.config.remote['auth-type'] === 'floodgate' && response.bootstrapInfo.platform === 'SPIGOT') {
+      for (const item of response.bootstrapInfo.plugins) {
+        if (item.name === 'Citizens' || item.name === 'Denizen') {
+          const embed = {
+            title: 'Citizens/Denizen Discord Warning',
+            color: 0xff0000,
+            description: "The Citizens Discord will not give support for users who are running Floodgate."
+          }
+          msg.channel.send({ embed })
+          break
+        }
+      }
+    }
   })
 }


### PR DESCRIPTION
At this time, Citizens is applying a DoNotSupport role to those who are running Floodgate. This warns users running Citizens and Floodgate that support will be denied for them.