### PR TITLE
Add clean-text-utils to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,6 +1167,11 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "clean-text-utils": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/clean-text-utils/-/clean-text-utils-1.1.17.tgz",
+      "integrity": "sha512-Y+1l2vrQwJbORnVrk9p0gSTgLtXIZRERvngyXTwmguaD/PMYvqj7FUF18/WZnwbGaJrFm99jafOhj0D4inx5vQ=="
+    },
     "cli-boxes": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "axios": "^0.21.0",
     "cheerio": "^1.0.0-rc.3",
+    "clean-text-utils": "^1.1.17",
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",


### PR DESCRIPTION
Fixes `clean-text-utils` being missing from the `package.json`