### PR TITLE
Add IPBan Warning.

### DIFF
--- a/tags/info/geyserconnect.tag
+++ b/tags/info/geyserconnect.tag
@@ -6,4 +6,4 @@ There is an **Unofficial** public [GeyserConnect](https://github.com/GeyserMC/Ge
 Address: `geyserconnect.gq`
 Port: `17193`
 
-**Warning:** Due to Geyser handling certain things different to a vanilla Java client you may get banned using this (see `!tag anticheat` for more info). As well as this, if you use online mode you are sending your Java account credentials to a third party.
+**Warning:** Due to Geyser handling certain things different to a vanilla Java client you may get banned using this (see `!tag anticheat` for more info), you can also instantly get banned on large servers when using GeyserConnect, due to the IP being banned. As well as this, if you use online mode you are sending your Java account credentials to a third party.

--- a/tags/info/geyserconnect.tag
+++ b/tags/info/geyserconnect.tag
@@ -6,4 +6,4 @@ There is an **Unofficial** public [GeyserConnect](https://github.com/GeyserMC/Ge
 Address: `geyserconnect.gq`
 Port: `17193`
 
-**Warning:** Due to Geyser handling certain things different to a vanilla Java client you may get banned using this (see `!tag anticheat` for more info), you can also instantly get banned on large servers when using GeyserConnect, due to the IP being banned. As well as this, if you use online mode you are sending your Java account credentials to a third party.
+**Warning:** Due to Geyser handling certain things different to a vanilla Java client you may get banned using this (see `!tag anticheat` for more info), you can also get banned on large servers when using GeyserConnect, due to the IP being banned. As well as this, if you use online mode you are sending your Java account credentials to a third party.


### PR DESCRIPTION
When connecting to a server with the public GeyserConnect, there is a possibility of getting instantly banned, due to the GeyserConnect IP being IP Banned, most people who use this tag don't warn of this, so there needs to be a warning in the tag to prevent peoples Java accounts getting banned.