### PR TITLE
Create autopublish module

### DIFF
--- a/bot_modules/autopublish/index.js
+++ b/bot_modules/autopublish/index.js
@@ -1,14 +1,6 @@
-const { Client } = require('discord.js')
-
-/**
- * @type {Array}
- */
 const { configEditor: config } = require('../config_manager/index.js')
 
-/**
- * @param {Client} client 
- */
-exports.init = function(client) {
+exports.init = function (client) {
   client.on('message', msg => {
     if (config.get().autopublishChannels.includes(msg.channel.id) && msg.crosspostable) {
       msg.crosspost()

--- a/bot_modules/autopublish/index.js
+++ b/bot_modules/autopublish/index.js
@@ -1,0 +1,17 @@
+const { Client } = require('discord.js')
+
+/**
+ * @type {Array}
+ */
+const { configEditor: config } = require('../config_manager/index.js')
+
+/**
+ * @param {Client} client 
+ */
+exports.init = function(client) {
+  client.on('message', msg => {
+    if (config.get().autopublishChannels.includes(msg.channel.id) && msg.crosspostable) {
+      msg.crosspost()
+    }
+  })
+}

--- a/config.json.example
+++ b/config.json.example
@@ -10,6 +10,7 @@
     }
   ],
   "discordUpdateChannels": ["349264069007638530"],
+  "autopublishChannels": ["744288680201682966","613195308930826246"],
   "logChannel": "614877230811709474",
   "convertExtensions": [".txt", ".log", ".yml"],
   "exceptionExtensions": [".txt", ".log"],

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ client.on('ready', () => {
   initialiseModule('search_commands')
   initialiseModule('attachment_converter')
   initialiseModule('error_analyse')
+  initialiseModule('autopublish')
   initialiseModule('help_command')
 })
 


### PR DESCRIPTION
Why make #ci-feeds and #git-feeds announcement channels if messages are never published? This module solves the problem by automatically publishing all messages sent in these channels (or those defined in the "autopublishChannels" property of config.json) 