### PR TITLE
Update address in geyserconnect.tag

### DIFF
--- a/tags/info/geyserconnect.tag
+++ b/tags/info/geyserconnect.tag
@@ -3,7 +3,7 @@ type: text
 ---
 
 There is an **Unofficial** public [GeyserConnect](https://github.com/GeyserMC/GeyserConnect) instance running. You can connect to it via
-Address: `geyserconnect.gq`
+Address: `geyserconnect.net`
 Port: `19132`
 
 Console users please review https://www.youtube.com/watch?v=IK-cx1PTfHY for details on setting this up on your console.


### PR DESCRIPTION
Updates the address from `geyserconnect.gq` to`geyserconnect.net`

From GeyserConnect discord: 

"Big news guys! We are migrating from the current domain name to `geyserconnect.net`! We haven't transitioned fully yet to the new domain, but it is usable if you wish to give it a try! We're aiming to have it fully migrated sometime next month."