### PR TITLE
Make logs.tag more forward

### DIFF
--- a/src/main/resources/tags/util/logs.tag
+++ b/src/main/resources/tags/util/logs.tag
@@ -3,5 +3,5 @@ aliases: log, mclogs
 
 ---
 
-If you want to share your logs while keeping your IP addresses private, use https://mclo.gs/ and give us the link after you saved it. 
-For BungeeCord there is a `proxy.log.0` file in the root and for everything else it is `latest.log` in `logs` folder.
+Please share your *full* logs by uploading to https://mclo.gs/ and sharing the link after you have saved it. All IP addresses will be hidden.
+For BungeeCord there is a proxy.log.0 file in the root folder and for everything else it is latest.log in logs folder.

--- a/src/main/resources/tags/util/logs.tag
+++ b/src/main/resources/tags/util/logs.tag
@@ -3,5 +3,7 @@ aliases: log, mclogs
 
 ---
 
-Please share your *full* logs by uploading to https://mclo.gs/ and sharing the link after you have saved it. All IP addresses will be hidden.
-For BungeeCord there is a proxy.log.0 file in the root folder and for everything else it is latest.log in logs folder.
+An entire log file is a very useful way of debugging any issues with plugins. Sometimes a snippet of a log doesn't tell the whole story!
+
+You can upload your log file into this channel, or you can use https://mclo.gs/ to censor all IPs present in your log.
+For BungeeCord (not Waterfall) there is a `proxy.log.0` file in the root and for everything else it is `latest.log` in `logs` folder.


### PR DESCRIPTION
To whoever it may concern, feel free to edit this to your liking

Camotoy also suggested this: 

```
An entire log file is a very useful way    of debugging any issues    with plugins. Sometimes    a snippet of a log doesn't tell    the whole story!

You can upload your log file into this channel, or you can use https://mclo.gs/ to censor all IPs present in your log. 
For BungeeCord (not Waterfall) there is a `proxy.log.0` file in the root and for everything else it is `latest.log` in `logs` folder.
```