### PR TITLE
Update Skinsrestorer.

### DIFF
--- a/src/main/resources/tags/info/skinsrestorer.tag
+++ b/src/main/resources/tags/info/skinsrestorer.tag
@@ -3,4 +3,4 @@ aliases: betojeskin, skinrestorer, betojeskins
 
 ---
 
-Currently, Geyser doesn't show skins of Bedrock players to Java players. That can be partially solved by using the SkinsRestorer plugin https://www.spigotmc.org/resources/skinsrestorer.2124/. You can use the command `/skin set <skinURL>` to set the skin to the one you want to use. Reminder: you should use `.` instead of `*` in the name of the player when using the command if you use Floodgate, this can be altered in the Floodgate config file.
+Geyser/Floodgate now shows skins to Java players. Some skins however may not appear. Please refer to "!!skins" for more information.

--- a/src/main/resources/tags/info/skinsrestorer.tag
+++ b/src/main/resources/tags/info/skinsrestorer.tag
@@ -1,6 +1,0 @@
-type: text
-aliases: betojeskin, skinrestorer, betojeskins
-
----
-
-Geyser/Floodgate now shows skins to Java players. Some skins however may not appear. Please refer to "!!skins" for more information.


### PR DESCRIPTION
I really think this tag should actually be deleted. Skins restorer really shouldn't have much use anymore because skins are shown. People who still use it probably have offline mode off instead of on without floodgate. (Even then if they had floodgate they probably still have offline mode off) In that case also Geyser Skin Manager shows the skins regardless now (Not for persona I dont think)

(if it doesn't get deleted atleast change the tag to say that floodgate now works with skins)