### PR TITLE
Update JDA-Chewtils to 1.23.0 and utilize OptionHelper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>pw.chew</groupId>
             <artifactId>jda-chewtils</artifactId>
-            <version>1.22.0</version>
+            <version>1.23.0</version>
             <scope>compile</scope>
             <type>pom</type>
         </dependency>

--- a/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
@@ -34,6 +34,7 @@ import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.geysermc.discordbot.util.BotColors;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.util.*;
 
@@ -91,7 +92,7 @@ public class DownloadCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        String program = event.getOptions().size() > 0 ? event.getOptions().get(0).getAsString() : "geyser";
+        String program = OptionHelper.optString(event, "program", "geyser");
 
         DownloadOption downloadOption = optionsToRepository.getOrDefault(program.toLowerCase(Locale.ROOT), this.defaultDownloadOption);
 

--- a/src/main/java/org/geysermc/discordbot/commands/IssueCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/IssueCommand.java
@@ -42,6 +42,7 @@ import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.PagedSearchIterable;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.awt.Color;
 import java.io.IOException;
@@ -71,9 +72,9 @@ public class IssueCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
         // Issue
-        int issue = (int) event.getOption("number").getAsLong();
+        int issue = (int) OptionHelper.optLong(event, "number", 0);
         // Repo
-        String repo = event.getOptions().size() > 1 ? event.getOption("repo").getAsString() : "";
+        String repo = OptionHelper.optString(event, "repo", "GeyserMC/Geyser");
 
         event.replyEmbeds(handle(issue, repo)).queue();
     }

--- a/src/main/java/org/geysermc/discordbot/commands/LevelCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/LevelCommand.java
@@ -45,6 +45,7 @@ import org.geysermc.discordbot.util.BotHelpers;
 import org.geysermc.discordbot.util.InkscapeCssParser;
 import org.geysermc.discordbot.util.MessageHelper;
 import org.w3c.dom.Document;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -69,10 +70,7 @@ public class LevelCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        Member member = event.getMember();
-        if (event.getOption("member") != null) {
-            member = event.getOption("member").getAsMember();
-        }
+        Member member = OptionHelper.optMember(event, "member", event.getMember());
 
         // Defer to wait for us to load a response and allows for files to be uploaded
         InteractionHook interactionHook = event.deferReply().complete();

--- a/src/main/java/org/geysermc/discordbot/commands/MemberCountCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/MemberCountCommand.java
@@ -36,6 +36,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.geysermc.discordbot.util.BotColors;
 import org.geysermc.discordbot.util.BotHelpers;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -56,10 +57,7 @@ public class MemberCountCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        Role role = null;
-        if (event.getOption("role") != null) {
-            role = event.getOption("role").getAsRole();
-        }
+        Role role = OptionHelper.optRole(event, "role", null);
 
         event.replyEmbeds(handle(event.getGuild(), role)).queue();
     }

--- a/src/main/java/org/geysermc/discordbot/commands/RankCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/RankCommand.java
@@ -38,6 +38,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.geysermc.discordbot.storage.ServerSettings;
 import org.geysermc.discordbot.util.BotColors;
 import org.geysermc.discordbot.util.MessageHelper;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.time.Instant;
 import java.util.*;
@@ -57,7 +58,7 @@ public class RankCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        String role = event.getOption("role").getAsString();
+        String role = OptionHelper.optString(event, "role", "");
 
         event.replyEmbeds(handle(event.getGuild(), event.getMember(), role)).queue();
     }

--- a/src/main/java/org/geysermc/discordbot/commands/TagsCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/TagsCommand.java
@@ -36,6 +36,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.geysermc.discordbot.tags.TagsManager;
 import org.geysermc.discordbot.util.BotColors;
 import org.geysermc.discordbot.util.PropertiesManager;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,10 +57,7 @@ public class TagsCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        String search = "";
-        if (event.getOption("search") != null) {
-            search = event.getOption("search").getAsString();
-        }
+        String search = OptionHelper.optString(event, "search", "");
 
         event.replyEmbeds(handle(search)).queue();
     }

--- a/src/main/java/org/geysermc/discordbot/commands/WhoisCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/WhoisCommand.java
@@ -39,6 +39,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.utils.TimeFormat;
 import org.geysermc.discordbot.util.BotHelpers;
 import org.geysermc.discordbot.util.MessageHelper;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -63,10 +64,7 @@ public class WhoisCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        Member member = event.getMember();
-        if (event.getOption("member") != null) {
-            member = event.getOption("member").getAsMember();
-        }
+        Member member = OptionHelper.optMember(event, "member", event.getMember());
 
         event.replyEmbeds(handle(member)).queue();
     }

--- a/src/main/java/org/geysermc/discordbot/commands/search/ProviderCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/search/ProviderCommand.java
@@ -36,6 +36,7 @@ import org.geysermc.discordbot.util.BotColors;
 import org.geysermc.discordbot.util.DicesCoefficient;
 import org.geysermc.discordbot.util.MessageHelper;
 import pw.chew.chewbotcca.util.RestClient;
+import pw.chew.jdachewtils.command.OptionHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,7 +60,7 @@ public class ProviderCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        event.replyEmbeds(handle(event.getOption("provider").getAsString())).queue();
+        event.replyEmbeds(handle(OptionHelper.optString(event, "provider", ""))).queue();
     }
 
     @Override

--- a/src/main/java/org/geysermc/discordbot/commands/search/WikiCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/search/WikiCommand.java
@@ -40,8 +40,8 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import pw.chew.chewbotcca.util.RestClient;
+import pw.chew.jdachewtils.command.OptionHelper;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -66,7 +66,7 @@ public class WikiCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
         // Get arguments
-        String args = event.getOption("search").getAsString();
+        String args = OptionHelper.optString(event, "search", "");
         MessageEmbed response = handle(args);
         if (response != null) event.replyEmbeds(response).queue();
     }


### PR DESCRIPTION
Version 1.23.0 of Chewtils finally dropped, releasing OptionHelper.

This utilizes that method to shorten the calls we make and remove the nullability warnings when retrieving options.

Docs: https://chew.pro/JDA-Chewtils/pw/chew/jdachewtils/command/OptionHelper.html