### PR TITLE
Add a tag for invalid Floodgate prefixes

### DIFF
--- a/src/main/resources/tags/errors/invalidprefix.tag
+++ b/src/main/resources/tags/errors/invalidprefix.tag
@@ -1,0 +1,6 @@
+type: text
+issues: org.yaml.snakeyaml.scanner.ScannerException: while scanning an alias
+
+---
+
+The `username-prefix` defined in Floodgate isn't valid YAML, please ensure that special characters are properly escaped. For example, a prefix of '*' should be `username-prefix: '*'`.


### PR DESCRIPTION
Add a tag for invalid Floodgate prefixes. The Floodgate plugin will fail to load if an invalid prefix is provided. This is but one variation of the error that I have seen.