### PR TITLE
Remove Floodgate '2.0' from `floodgateskins`

### DIFF
--- a/src/main/resources/tags/info/floodgateskins.tag
+++ b/src/main/resources/tags/info/floodgateskins.tag
@@ -3,7 +3,7 @@ aliases: skin, skins
 
 ---
 
-Skins of Bedrock player should be visible to Java players on servers with [Floodgate 2.0](https://wiki.geysermc.org/floodgate/) installed.
+Skins of Bedrock player should be visible to Java players on servers with [Floodgate](https://wiki.geysermc.org/floodgate/) installed.
 If they aren't, it's possible that the skin the player is using isn't supported (Such as Persona Skins with drastically different 3D models), or that the queue for skin uploading has grown too large (and you must simply wait).
 
 If you are using BungeeCord/Velocity: Installing Floodgate on the backend servers also makes it so that Bedrock player's don't have to switch backend servers for their skins to start displaying.


### PR DESCRIPTION
As mentioned in the GeyserMC Discord, specifically referring to Floodgate 2.0 is no longer required.