### PR TITLE
Remove Java class from `addressinuse`

### DIFF
--- a/src/main/resources/tags/errors/addressinuse.tag
+++ b/src/main/resources/tags/errors/addressinuse.tag
@@ -1,5 +1,5 @@
 type: text
-issues: java.net.BindException: Address already in use
+issues: java.net.BindException: Address already in use || bind(..) failed: Address already in use
 aliases: bind, failedtobind, bindissue, addressalreadyinuse
 
 ---

--- a/src/main/resources/tags/errors/addressinuse.tag
+++ b/src/main/resources/tags/errors/addressinuse.tag
@@ -1,5 +1,5 @@
 type: text
-issues: java.net.BindException: Address already in use || bind(..) failed: Address already in use
+issues: Address already in use
 aliases: bind, failedtobind, bindissue, addressalreadyinuse
 
 ---


### PR DESCRIPTION
Reduces the `addressinuse` error to only search for `Address already in use` as multiple classes can produce this error.