### PR TITLE
Update asking.tag

### DIFF
--- a/src/main/resources/tags/util/asking.tag
+++ b/src/main/resources/tags/util/asking.tag
@@ -1,6 +1,6 @@
 type: text-raw
-aliases: ask
+aliases: ask, help
 
 ---
 
-https://dontasktoa.sk/
+Don't ask to ask, just ask your question. Don't ask if someone can help you. Just explain what you need help with, and provide as much information about your issue and server as possible.


### PR DESCRIPTION
The gif is too beefy, and its dimensions fills channels. People can't use a translator on it. "Don't ask to ask, just ask" is probably vague and confusing to those who don't have english as a main language. The website is informative but its arguably too long for those who won't formulate a question, and I doubt many people click it after seeing the gif.