### PR TITLE
Update GeyserConnect website links after rehaul

### DIFF
--- a/src/main/resources/tags/info/geyserconnect.tag
+++ b/src/main/resources/tags/info/geyserconnect.tag
@@ -10,10 +10,10 @@ Europe: `eu.geyserconnect.net`
 Port: `19132` for both addresses.
 
 More information is available on their [website](https://www.geyserconnect.net)
-[Xbox Users](https://www.geyserconnect.net/pages/guides/xbox)
-[Switch Users](https://www.geyserconnect.net/pages/guides/switch)
-[PlayStation Users](https://www.geyserconnect.net/pages/guides/playstation)
+[Xbox Users](https://www.geyserconnect.net/guide/xbox)
+[Switch Users](https://www.geyserconnect.net/guide/switch)
+[PlayStation Users](https://www.geyserconnect.net/guide/playstation)
 
-You can also join the [Discord](https://www.geyserconnect.net/pages/redirects/discord)
+You can also join the [Discord](https://discord.com/invite/3r7T9fXzDE)
 
 **Warning:** Due to Geyser handling certain things different to a vanilla Java client you may get banned using this (see `!tag anticheat` for more info). As well as this, if you use online mode you are sending your Java account credentials to a third party.

--- a/src/main/resources/tags/info/geyserconnect.tag
+++ b/src/main/resources/tags/info/geyserconnect.tag
@@ -10,9 +10,10 @@ Europe: `eu.geyserconnect.net`
 Port: `19132` for both addresses.
 
 More information is available on their [website](https://www.geyserconnect.net)
-[Xbox/Switch users](https://www.geyserconnect.net/xbox-switch.htm)
-[PlayStation users](https://www.geyserconnect.net/playstation.htm)
+[Xbox Users](https://www.geyserconnect.net/pages/guides/xbox)
+[Switch Users](https://www.geyserconnect.net/pages/guides/switch)
+[PlayStation Users](https://www.geyserconnect.net/pages/guides/playstation)
 
-You can also join the [Discord](https://discord.gg/3r7T9fXzDE)
+You can also join the [Discord](https://www.geyserconnect.net/pages/redirects/discord/demi lo)
 
 **Warning:** Due to Geyser handling certain things different to a vanilla Java client you may get banned using this (see `!tag anticheat` for more info). As well as this, if you use online mode you are sending your Java account credentials to a third party.

--- a/src/main/resources/tags/info/geyserconnect.tag
+++ b/src/main/resources/tags/info/geyserconnect.tag
@@ -14,6 +14,6 @@ More information is available on their [website](https://www.geyserconnect.net)
 [Switch Users](https://www.geyserconnect.net/pages/guides/switch)
 [PlayStation Users](https://www.geyserconnect.net/pages/guides/playstation)
 
-You can also join the [Discord](https://www.geyserconnect.net/pages/redirects/discord/demi lo)
+You can also join the [Discord](https://www.geyserconnect.net/pages/redirects/discord)
 
 **Warning:** Due to Geyser handling certain things different to a vanilla Java client you may get banned using this (see `!tag anticheat` for more info). As well as this, if you use online mode you are sending your Java account credentials to a third party.


### PR DESCRIPTION
When I redesigned the website, I have also changed the structure and layout of the pages. This fixes the old links.