### PR TITLE
fix broken wiki link

### DIFF
--- a/src/main/resources/tags/info/accountlinking.tag
+++ b/src/main/resources/tags/info/accountlinking.tag
@@ -4,5 +4,5 @@ aliases: linkaccount, globallinking
 ---
 
 Information on how to use Global Linking can be found here: https://link.geysermc.org/
-Information on how to setup and use both Global Linking and Local Linking can be found here: https://wiki.geysermc.org/floodgate/features/#what-is-global-linking
+Information on how to setup and use both Global Linking and Local Linking can be found here: https://wiki.geysermc.org/floodgate/linking/
 To unlink your accounts, join the Global Link Server on one of the linked accounts and use the `/unlinkaccount` command.


### PR DESCRIPTION
title - also, I've removed the quick link to "what-is-global-linking" specifically, since it 1. lands on the same page anyways and 2. isn't needed in this context