### PR TITLE
Fix subdomains of checkdomains being filtered

### DIFF
--- a/src/main/java/org/geysermc/discordbot/listeners/BadLinksHandler.java
+++ b/src/main/java/org/geysermc/discordbot/listeners/BadLinksHandler.java
@@ -83,6 +83,7 @@ public class BadLinksHandler extends ListenerAdapter {
                     if (domain.endsWith("." + checkDomain) || domain.equals(checkDomain)) {
                         // If the domain is a good domain or a subdomain of a good domain, don't compare
                         compareDomainNeeded = false;
+                        break;
                     }
                 }
                 if (compareDomainNeeded) {

--- a/src/main/java/org/geysermc/discordbot/listeners/BadLinksHandler.java
+++ b/src/main/java/org/geysermc/discordbot/listeners/BadLinksHandler.java
@@ -78,8 +78,8 @@ public class BadLinksHandler extends ListenerAdapter {
             }
 
             if (!foundMatch) {
+                boolean compareDomainNeeded = true;
                 for (String checkDomain : checkDomains) {
-                    boolean compareDomainNeeded = true;
                     if (domain.endsWith("." + checkDomain) || domain.equals(checkDomain)) {
                         // If the domain is a good domain or a subdomain of a good domain, don't compare
                         compareDomainNeeded = false;

--- a/src/main/java/org/geysermc/discordbot/listeners/BadLinksHandler.java
+++ b/src/main/java/org/geysermc/discordbot/listeners/BadLinksHandler.java
@@ -79,12 +79,20 @@ public class BadLinksHandler extends ListenerAdapter {
 
             if (!foundMatch) {
                 for (String checkDomain : checkDomains) {
-                    // Is the domain not exact but still close
-                    if (!domain.equals(checkDomain) && compareDomain(domain, checkDomain)) {
-                        foundMatch = true;
-                        foundDomain = checkDomain;
-
-                        break;
+                    boolean compareDomainNeeded = true;
+                    if (domain.endsWith("." + checkDomain) || domain.equals(checkDomain)) {
+                        // If the domain is a good domain or a subdomain of a good domain, don't compare
+                        compareDomainNeeded = false;
+                    }
+                }
+                if (compareDomainNeeded) {
+                    for (String checkDomain : checkDomains) {
+                        // Is the domain not exact but still close
+                        if (compareDomain(domain, checkDomain)) {
+                            foundMatch = true;
+                            foundDomain = checkDomain;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Currently domains like `gist.github.com` and `github.dev` are filtered, despite being legitimate GitHub owned properties. This PR resolves this by first checking if the link in question is a domain or subdomain for a domain on the check domain list. The fuzzy match filter is then only applied if that condition was not met.