### PR TITLE
Add a "ps5" alias to !!ps4 for convenience

### DIFF
--- a/src/main/resources/tags/links/consoles.tag
+++ b/src/main/resources/tags/links/consoles.tag
@@ -1,5 +1,5 @@
 type: text
-aliases: bedrockconnect, ps4, xbox, switch
+aliases: bedrockconnect, ps4, ps5, xbox, switch
 
 ---
 


### PR DESCRIPTION
Saw someone in support ask whether it will work with a PS5 after someone used !!ps4 and decided to add this. A small wiki change should also probably be made include info about PS5.