### PR TITLE
Remove standalone GUI info from dump tags

### DIFF
--- a/src/main/resources/tags/util/dump.tag
+++ b/src/main/resources/tags/util/dump.tag
@@ -1,8 +1,5 @@
 type: text
-image: https://media.discordapp.net/attachments/774372288061243482/776957132465373184/97361099-751ce400-1875-11eb-84b5-2945d840dfff.png
 
 ---
 
 Run `geyser dump` (server console) / `/geyser dump` (ingame chat) on your Geyser instance or server, then copy the link it will give you and paste it here. A Geyser dump is a way of providing us with a bunch of useful information about your server and Geyser config. This doesn't include any IPs or sensitive data.
-
-If you use the Geyser Standalone GUI then it is inside the `Commands` menu as seen below.

--- a/src/main/resources/tags/util/fulldump.tag
+++ b/src/main/resources/tags/util/fulldump.tag
@@ -1,8 +1,5 @@
 type: text
-image: https://media.discordapp.net/attachments/774372288061243482/776957132465373184/97361099-751ce400-1875-11eb-84b5-2945d840dfff.png
 
 ---
 
 Run `geyser dump full` (server console) / `/geyser dump full` (ingame chat) on your Geyser instance or server, then copy the link it will give you and paste it here. This will show all IPs on your dump so we can correctly identify your issue.
-
-If you use the Geyser Standalone GUI then it is inside the `Commands` menu as seen below.

--- a/src/main/resources/tags/util/logsdump.tag
+++ b/src/main/resources/tags/util/logsdump.tag
@@ -1,8 +1,5 @@
 type: text
-image: https://media.discordapp.net/attachments/774372288061243482/776957132465373184/97361099-751ce400-1875-11eb-84b5-2945d840dfff.png
 
 ---
 
 Run `geyser dump logs` (server console) / `/geyser dump logs` (ingame chat) on your Geyser instance or server, then copy the link it will give you and paste it here. This will automatically upload the server logs to [mclo.gs](https://mclo.gs/) and add the link in the dump.
-
-If you use the Geyser Standalone GUI then it is inside the `Commands` menu as seen below.


### PR DESCRIPTION
Alternative info for standalone GUI is no longer necessary with https://github.com/GeyserMC/Geyser/pull/3915