### PR TITLE
Fix duplicate `Geyser` options appearing in the `/download` command

### DIFF
--- a/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
@@ -43,7 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 
 public class DownloadCommand extends SlashCommand {
-    private final String defaultDownloadOption;
+    private final DownloadOption defaultDownloadOption;
     private final Map<String, DownloadOption> optionsToRepository;
 
     public DownloadCommand() {
@@ -52,10 +52,10 @@ public class DownloadCommand extends SlashCommand {
         this.help = "Sends a link to download the latest version of Geyser or another program";
         this.guildOnly = false;
 
-        this.defaultDownloadOption = "https://geysermc.org/download";
+        this.defaultDownloadOption = new GeyserDownloadOption("Geyser", "https://geysermc.org/download");
         this.optionsToRepository = ImmutableMap.<String, DownloadOption>builder()
-                .put("geyser", new GeyserDownloadOption("Geyser", this.defaultDownloadOption))
-                .put("floodgate", new GeyserDownloadOption("Floodgate", this.defaultDownloadOption))
+                .put("geyser", new GeyserDownloadOption("Geyser", this.defaultDownloadOption.downloadUrl))
+                .put("floodgate", new GeyserDownloadOption("Floodgate", this.defaultDownloadOption.downloadUrl))
                 .put("geyseroptionalpack", new GeyserDownloadOption("GeyserOptionalPack", "https://ci.opencollab.dev/job/GeyserMC/job/GeyserOptionalPack/job/master/"))
                 .put("floodgate-fabric", new FabricDownloadOption("Floodgate-Fabric", "https://modrinth.com/mod/floodgate"))
                 .put("paper", new DownloadOption("Paper", "https://papermc.io/downloads", "https://github.com/PaperMC.png"))

--- a/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
@@ -43,7 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 
 public class DownloadCommand extends SlashCommand {
-    private final DownloadOption defaultDownloadOption;
+    private final String defaultDownloadOption;
     private final Map<String, DownloadOption> optionsToRepository;
 
     public DownloadCommand() {
@@ -52,10 +52,10 @@ public class DownloadCommand extends SlashCommand {
         this.help = "Sends a link to download the latest version of Geyser or another program";
         this.guildOnly = false;
 
-        this.defaultDownloadOption = new GeyserDownloadOption("Geyser", "https://geysermc.org/download");
+        this.defaultDownloadOption = "https://geysermc.org/download";
         this.optionsToRepository = ImmutableMap.<String, DownloadOption>builder()
-                .put("geyser", this.defaultDownloadOption)
-                .put("floodgate", this.defaultDownloadOption)
+                .put("geyser", new GeyserDownloadOption("Geyser", this.defaultDownloadOption))
+                .put("floodgate", new GeyserDownloadOption("Floodgate", this.defaultDownloadOption))
                 .put("geyseroptionalpack", new GeyserDownloadOption("GeyserOptionalPack", "https://ci.opencollab.dev/job/GeyserMC/job/GeyserOptionalPack/job/master/"))
                 .put("floodgate-fabric", new FabricDownloadOption("Floodgate-Fabric", "https://modrinth.com/mod/floodgate"))
                 .put("paper", new DownloadOption("Paper", "https://papermc.io/downloads", "https://github.com/PaperMC.png"))

--- a/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/DownloadCommand.java
@@ -54,7 +54,7 @@ public class DownloadCommand extends SlashCommand {
 
         this.defaultDownloadOption = new GeyserDownloadOption("Geyser", "https://geysermc.org/download");
         this.optionsToRepository = ImmutableMap.<String, DownloadOption>builder()
-                .put("geyser", new GeyserDownloadOption("Geyser", this.defaultDownloadOption.downloadUrl))
+                .put("geyser", this.defaultDownloadOption)
                 .put("floodgate", new GeyserDownloadOption("Floodgate", this.defaultDownloadOption.downloadUrl))
                 .put("geyseroptionalpack", new GeyserDownloadOption("GeyserOptionalPack", "https://ci.opencollab.dev/job/GeyserMC/job/GeyserOptionalPack/job/master/"))
                 .put("floodgate-fabric", new FabricDownloadOption("Floodgate-Fabric", "https://modrinth.com/mod/floodgate"))


### PR DESCRIPTION
The current `/download` command contains two options with the name `Geyser`. The values of this options are `geyser` and `floodgate`. `DownloadCommand.defaultDownloadOption` sets the command name to always be `Geyser` and to always use the Geyser download URL as the destination, causing a duplicate entry in the list even though the command that Discord receives has a different value.

This PR makes the following changes:
- Changes the `geyser` and `floodgate` commands to be `DownloadOption` where the command name is `Geyser` or `Floodgate` and the target URL is `defaultDownloadOption.downloadUrl`