### PR TITLE
Add OVH tag, remove android.tag, adjust other tags slightly

### DIFF
--- a/src/main/resources/tags/errors/addressinuse.tag
+++ b/src/main/resources/tags/errors/addressinuse.tag
@@ -5,3 +5,4 @@ aliases: bind, failedtobind, bindissue, addressalreadyinuse
 ---
 
 This means something (likely another instance of Geyser) is running on the port you have specified in the config. Please make sure you close all applications running on this port. If you don't recall opening anything, usually restarting your computer fixes this.
+If you are using a server hosting provider and get this error, you likely need to use a specific port allocated to you. See the [setup guide](https://wiki.geysermc.org/geyser/setup/) for instructions on how to configure Geyser.

--- a/src/main/resources/tags/errors/aesunavailable.tag
+++ b/src/main/resources/tags/errors/aesunavailable.tag
@@ -1,6 +1,0 @@
-type: issue-only
-issues: java.lang.AssertionError: Expected AES to be available
-
----
-
-Update your Java at [Adoptium.net](https://adoptium.net/).

--- a/src/main/resources/tags/errors/closedchannelexception.tag
+++ b/src/main/resources/tags/errors/closedchannelexception.tag
@@ -3,4 +3,5 @@ issues: ClosedChannelException
 
 ---
 
-This error can be caused by various things. Please upload your logs using https://mclo.gs and paste them in <#613168464634576897>.
+This error can be caused by various things. Please upload your logs using https://mclo.gs/ and paste them in <#613168464634576897>.
+If you are getting this error on a proxy server such as Velocity or BungeeCord, check your backend server logs for errors.

--- a/src/main/resources/tags/errors/connectionclosed.tag
+++ b/src/main/resources/tags/errors/connectionclosed.tag
@@ -3,4 +3,5 @@ issues: Connection closed
 
 ---
 
-This error is probably caused by a connection error. Upload your logs with http://mclo.gs and paste the URL here.
+This error is probably caused by a connection error. Upload your logs with http://mclo.gs/ and paste the URL here.
+If you are getting this error on a proxy server such as Velocity or BungeeCord, check your backend server logs for errors.

--- a/src/main/resources/tags/errors/unabletoconnect.tag
+++ b/src/main/resources/tags/errors/unabletoconnect.tag
@@ -3,5 +3,8 @@ issues: Unable to connect to world
 
 ---
 
-This means that the Bedrock client cannot find the server specified. This is most likely not a Geyser issue itself, unless Geyser is not running.
-There are various fixes for this on our wiki, please see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/).
+This means that the Bedrock client cannot find the server specified.
+If you have not already, follow our [setup instructions](https://wiki.geysermc.org/geyser/setup/). Then, check the server console for any errors.
+To verify Bedrock clients can connect, you can try running the `geyser connectiontest <ip>:<port>` command with your server IP and Geyser port.
+
+Additionally, there are various fixes for this on our wiki, please see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/).

--- a/src/main/resources/tags/help/beta.tag
+++ b/src/main/resources/tags/help/beta.tag
@@ -1,7 +1,7 @@
 type: text
-aliases: betas, optout, exitbeta
+aliases: betas, preview
 
 ---
 
-Geyser does not support betas usually, you can opt out of Bedrock betas using this guide:
+Geyser does not support beta or preview versions usually, you can opt out of Bedrock betas using this guide:
 <https://help.minecraft.net/hc/en-us/articles/360040841471-How-to-Join-and-leave-a-Minecraft-Beta>

--- a/src/main/resources/tags/help/howtoportforward.tag
+++ b/src/main/resources/tags/help/howtoportforward.tag
@@ -4,4 +4,4 @@ help: portforward
 
 ---
 
-[Here](https://www.lifewire.com/how-to-port-forward-4163829) you can find a guide on how to properly forward ports on your router. Geyser uses the UDP protocol and the default Minecraft Bedrock port is `19132`.
+[Here](https://wiki.geysermc.org/geyser/port-forwarding/) you can find a guide on how to set up port forwarding. Geyser uses the UDP protocol and the default Minecraft Bedrock port is `19132`.

--- a/src/main/resources/tags/help/ip.tag
+++ b/src/main/resources/tags/help/ip.tag
@@ -3,8 +3,11 @@ aliases: address
 
 ---
 
-Geyser is software that you can download and run yourself, so it doesn't have an IP. That being said, there are a few Geyser-related services that do have an IP:
+When using Geyser as a plugin, the IP is usually the same as your Java server's ip.
+
+That being said, there are a few other Geyser-related services that have their own IP:
 
 - If you're looking for a hosted version of the GeyserConnect software, run `!!geyserconnect` in <#613194762249437245> for more info.
+It allows you to connect to most Java servers from Bedrock without having to install anything on the server.
 
-- If you just want to try out Geyser, we have a test server at `test.geysermc.org` - do `!!testserver` in <#613194762249437245> for more info.
+- If you just want to try out Geyser, we have a test server at `test.geysermc.org` - run `/tag testserver` in <#613194762249437245> for more info.

--- a/src/main/resources/tags/help/portforward.tag
+++ b/src/main/resources/tags/help/portforward.tag
@@ -4,5 +4,7 @@ image: https://i.ibb.co/7J0HhZF/Portforward.png
 ---
 
 **Test your server's port forwarding**
-**1.** Go [here](https://www.ipfingerprints.com/portscan.php)
-**2.** Follow the guide on this picture. Use the port that your Geyser uses (19132 is the default)
+1. Go [here](https://www.ipfingerprints.com/portscan.php)
+2. Follow the guide on this picture. Use the port that your Geyser uses (19132 is the default)
+
+Note: UDP port scanning is fairly unreliable, so this is just a possible indicator whether the port is blocked (closed), or likely open.

--- a/src/main/resources/tags/info/api.tag
+++ b/src/main/resources/tags/info/api.tag
@@ -8,5 +8,4 @@ There are multiple APIs available for different purposes.
 - The [Floodgate API](https://wiki.geysermc.org/floodgate/api/) allows plugins and mods to check for Bedrock players, or to get important information about them.
 - The [Geyser API](https://wiki.geysermc.org/geyser/api/) can be used to interact with Geyser itself - for example, by registering custom items or blocks, and listening to events.
 - You can use the [Global API](https://wiki.geysermc.org/geyser/global-api/) to get specific details about Bedrock players, such as linking status or converted Bedrock skins.
-
-Bedrock Edition features built-in GUIs. See the [Cumulus API](https://wiki.geysermc.org/geyser/forms/) for more information on how to create and send those.
+- Bedrock Edition features built-in GUIs. See the [Cumulus API](https://wiki.geysermc.org/geyser/forms/) for more information on how to create and send those.

--- a/src/main/resources/tags/info/outdatedjava.tag
+++ b/src/main/resources/tags/info/outdatedjava.tag
@@ -7,5 +7,5 @@ issues: java.lang.UnsupportedClassVersionError
 Geyser currently requires Java 16 or later to run. You can download Java 17 at https://adoptium.net/temurin/releases/
 To find out how to change your Java version on hosts or other platforms, look at https://docs.papermc.io/java-install-update
 
-If you’re running a version of Paper that does not support Java 16 or later, you can add the flag -DPaper.IgnoreJavaVersion=true to your startup Java arguments to allow Paper to run on Java 16.
+If you’re running a version of Paper that does not support Java 16 or later, you can add the flag `-DPaper.IgnoreJavaVersion=true` to your startup Java arguments to allow Paper to run on Java 16.
 You can run Geyser standalone on another device if a server software cannot be updated to use Java 16.

--- a/src/main/resources/tags/info/ovh.tag
+++ b/src/main/resources/tags/info/ovh.tag
@@ -1,0 +1,9 @@
+type: text
+aliases: oci, oracle
+
+---
+
+Some hosting providers, such as OVH, SoYouStart and Oracle Cloud (OCI) have firewall setups that block UDP traffic by default.
+
+For example, OVH's firewall requires an initial TCP ping before allowing UDP traffic, which prohibits clients from joining.
+See [here](https://wiki.geysermc.org/geyser/port-forwarding/#ovh-and-soyoustart) for info on how to resolve these issues.

--- a/src/main/resources/tags/links/android.tag
+++ b/src/main/resources/tags/links/android.tag
@@ -1,6 +1,0 @@
-type: text
-aliases: androidapp
-
----
-
-Geyser currently does not have an up-to-date Android app. But you could host Geyser Standalone in Termux on your Android device. Run `!tag termux` in <#613194762249437245> for more info on that.

--- a/src/main/resources/tags/links/termux.tag
+++ b/src/main/resources/tags/links/termux.tag
@@ -2,5 +2,7 @@ type: text
 
 ---
 
-The included link contains a guide on how to set up Geyser on Android using the third-party program called Termux. However, using the Android app is easier if possible (see `!tag android` for more information).
-https://wiki.geysermc.org/geyser/setup/#termux-android
+The included link contains a guide on how to set up Geyser on Android using the third-party program called Termux.
+https://wiki.geysermc.org/geyser/setup/ (navigate to self-host, then Geyser-Standalone).
+
+Note: Applications such as Termux on Android are capable of running Geyser-Standalone, but this largely depends on how powerful your Android device is. Please do so at your own risk.

--- a/src/main/resources/tags/links/whitelist.tag
+++ b/src/main/resources/tags/links/whitelist.tag
@@ -3,5 +3,7 @@ aliases: whitelisting, howtowhitelist
 
 ---
 
-See here for information about adding Bedrock players to the whitelist.json.
+See here for information about adding Bedrock players to the whitelist.
 https://wiki.geysermc.org/floodgate/features/#whitelist-command
+
+If whitelisting using the username does not work, you can get the Bedrock player's Floodgate UUID [here](https://mcprofile.io/) and whitelist it instead.

--- a/src/main/resources/tags/roles/news.tag
+++ b/src/main/resources/tags/roles/news.tag
@@ -3,4 +3,4 @@ aliases: geysernews
 
 ---
 
-Run `!rank geysernews` in the <#613194762249437245> channel if you wish to get notified when big updates come out.
+Run `/rank geysernews` in the <#613194762249437245> channel if you wish to get notified when big updates come out.

--- a/src/main/resources/tags/roles/tester.tag
+++ b/src/main/resources/tags/roles/tester.tag
@@ -3,4 +3,4 @@ aliases: testers, testing
 
 ---
 
-Want to test new Geyser features? Run `!rank Tester` in the <#613194762249437245> channel.
+Want to test new Geyser features? Run `/rank Tester` in the <#613194762249437245> channel.

--- a/src/main/resources/tags/util/connectiontest.tag
+++ b/src/main/resources/tags/util/connectiontest.tag
@@ -1,0 +1,10 @@
+type: text
+aliases: test, serverstatus
+
+---
+
+To check whether Bedrock players can connect or if port forwarding for Geyser is working, run the following command in your Minecraft server console:
+
+`geyser connectiontest <ip>:<port>`
+
+For example, if your server is running on the IP 12.34.56.78 and port 19132, you would run `geyser connectiontest 12.34.56.78:19132`.

--- a/src/main/resources/tags/util/mcsrvstatus.tag
+++ b/src/main/resources/tags/util/mcsrvstatus.tag
@@ -1,6 +1,0 @@
-type: text
-aliases: mcserverstatus, serverstatus, mcservstatus
-
----
-
-This website is an excellent tool for testing if your server can be reached from another computer. Provide both your IP and port when pinging a server: https://mcsrvstat.us/

--- a/src/test/java/org/geysermc/discordbot/commands/search/ProvidersTest.java
+++ b/src/test/java/org/geysermc/discordbot/commands/search/ProvidersTest.java
@@ -47,7 +47,7 @@ public class ProvidersTest {
     @Test
     public void testSimilarProviders() {
         assertEquals("MCProHosting", command.potentialProviders("mcrory").get(0).name());
-        assertEquals("Google Cloud", command.potentialProviders("Google").get(0).name());
+        assertEquals("Cloud Nord", command.potentialProviders("cloud").get(0).name());
     }
 
     @Test


### PR DESCRIPTION
Since https://github.com/GeyserMC/GeyserWiki/commit/d99084701f1521dcf89c2ef242af0737ff990b96, providers such as OVH and OCI are no longer on the providers list - hence, a new tag was needed (!!ovh/!!oci).
Additionally, I removed the mcsrvstatus tag in favor of the updated connectiontest command - it has a few more benefits, such as checking for the OVH firewall issue, checking for config mismatches, and telling the user whether they are checking their own server :p