### PR TITLE
Remove converter that deletes output directory

### DIFF
--- a/src/main/resources/tags/links/rpconvert.tag
+++ b/src/main/resources/tags/links/rpconvert.tag
@@ -7,8 +7,6 @@ Use this tool to convert your Java resource pack into a Bedrock resource pack to
 https://rtm516.github.io/ConvertJavaTextureToBedrock/
 Unfortunately, this tool is not updated to support packs for versions newer than 1.17.
 
-An updated alternative is this [Windows program](https://github.com/TheAlienDoctor/minecraft-resource-pack-converter).
-
 **Packs with CustomModelData**
 To convert a resource pack with CustomModelData, use the following converter: https://github.com/Kas-tle/java2bedrock.sh 
 For more info on how to use it, see the pinned messages in <#1139296287179677857>. Be advised: Converting a pack to make it Bedrock compatible, especially with CustomModelData isn't always an automated process. If you need help, ask in the aforementioned channel!


### PR DESCRIPTION
Unfortunately it seems the newer texture converter that we recommend in this tag will completely clear whatever directory the output directory is set to. While it does mention this when starting the program, we've already had one case in support where someone blew past it and yeeted their desktop...

Therefore I think it is dangerous to be recommending the use of this converter unless this behavior is corrected.

See:
- https://github.com/TheAlienDoctor/minecraft-resource-pack-converter/blob/main/index.au3#L662
- https://discord.com/channels/613163671870242838/1139296287179677857/1203078539264663694