### PR TITLE
Add MCXboxBroadcast tag

### DIFF
--- a/src/main/resources/tags/links/mcxboxbroadcast.tag
+++ b/src/main/resources/tags/links/mcxboxbroadcast.tag
@@ -5,7 +5,7 @@ button: [Download](https://github.com/MCXboxBroadcast/Broadcaster/)
 
 ---
 
-MCXboxBroadcast is tool for Geyser servers developed by <@170429173003714560>. It allows you to join a Geyser server by following or friending someone in Minecraft then joining that user.
+MCXboxBroadcast is tool for Geyser servers developed by rtm516. It allows you to join a Geyser server by following or friending someone in Minecraft then joining that user.
 
 It comes as a standalone application or an extension for Geyser, support is not typically provided here, however, there exists a support server linked below.
 

--- a/src/main/resources/tags/links/mcxboxbroadcast.tag
+++ b/src/main/resources/tags/links/mcxboxbroadcast.tag
@@ -1,0 +1,11 @@
+type: text
+aliases: minecraftxboxbroadcast, mcxb
+button: [Support Server](https://discord.gg/SDDfsuCcBX/)
+button: [Download](https://github.com/MCXboxBroadcast/Broadcaster/)
+
+---
+
+MCXboxBroadcast is tool for Geyser servers developed by <@170429173003714560>. It allows you to join a Geyser server by following or friending someone in Minecraft then joining that user.
+
+It comes as a standalone application or an extension for Geyser, support is not typically provided here, however, there exists a support server linked below.
+

--- a/src/main/resources/tags/links/mcxboxbroadcast.tag
+++ b/src/main/resources/tags/links/mcxboxbroadcast.tag
@@ -7,5 +7,5 @@ button: [Download](https://github.com/MCXboxBroadcast/Broadcaster/)
 
 MCXboxBroadcast is tool for Geyser servers developed by rtm516. It allows you to join a Geyser server by following or friending someone in Minecraft then joining that user.
 
-It comes as a standalone application or an extension for Geyser, support is not typically provided here, however, there exists a support server linked below.
+It comes as a standalone application or an extension for Geyser. Support is not typically provided here; however, there exists a support server linked below.
 


### PR DESCRIPTION
Adds just one tag, for information on MCXboxBroadcast, which includes a link to RTM's server (getting one can be annoying) and provides a little information to the user on what it actually is.