### PR TITLE
fix(tests): update provider test to use new name

### DIFF
--- a/src/test/java/org/geysermc/discordbot/commands/search/ProvidersTest.java
+++ b/src/test/java/org/geysermc/discordbot/commands/search/ProvidersTest.java
@@ -46,7 +46,7 @@ public class ProvidersTest {
 
     @Test
     public void testSimilarProviders() {
-        assertEquals("MCProHosting", command.potentialProviders("mcrory").get(0).name());
+        assertEquals("EnviroMC", command.potentialProviders("mcrory").get(0).name());
         assertEquals("Cloud Nord", command.potentialProviders("cloud").get(0).name());
     }
 


### PR DESCRIPTION
Since MCProHosting is gone, tests fail. Replace with what the first result is for "mcrory" now