### PR TITLE
Fix typo in tags README and add `newitems` tag

### DIFF
--- a/src/main/resources/tags/README.md
+++ b/src/main/resources/tags/README.md
@@ -20,7 +20,7 @@ type: text
 aliases: test1, test2
 image: https://example.com/example.png
 button: [View Rory](https://example.com)
-button: [Floodagte Wiki](https://wiki.geysermc.org/floodgate/)
+button: [Floodgate Wiki](https://wiki.geysermc.org/floodgate/)
 
 ---
 

--- a/src/main/resources/tags/info/newitems.tag
+++ b/src/main/resources/tags/info/newitems.tag
@@ -1,0 +1,7 @@
+type: text
+
+---
+
+Geyser's custom item system has not yet been updated to fully support Java's 1.21.4 item model definition format. There is a PR open for a [new custom item API](https://github.com/GeyserMC/Geyser/pull/5189), which adds support for 1.21.4 item definitions, their predicates, items with custom components, and more.
+
+Until this PR is merged, you can still use the current custom item API with the 1.21.4 format, by using `range_dispatch` conditions (checking for index 0 of the `custom_model_data` property) in Java resource packs. Note that you will not be able to use these resource packs with converters like Kastle's java2bedrock.sh.


### PR DESCRIPTION
Add a tag explaining that Geyser doesn't yet support 1.21.4's item definition format and how to use the current item API with it. Might need to be updated if the PR mentioned goes into testing.

Fixed a typo because I noticed it