### PR TITLE
Hide link preview embeds in donation feeds channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Most of these are lists which values are seperated by `,` and a few are seperate
 | `preview-feeds-channel` | News channel ID for preview feeds                                                    | `614877230811709474`                                        |
 | `preview-feeds`         | Forum channel ID for preview feeds                                                   | `614877230811709474`                                        |
 | `exploit-reports-notify-channel` | Channel ID to notify when an exploit report is made                         | `614877230811709474`                                        |
-| `donation-feeds-channel` | Channel ID to in which webhook messages from Open Collective are posted             | `873968290836385792`                                        |
+| `donation-feeds-channel` | Channel ID in which webhook messages from Open Collective are posted                | `873968290836385792`                                        |

--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Most of these are lists which values are seperated by `,` and a few are seperate
 | `preview-feeds-channel` | News channel ID for preview feeds                                                    | `614877230811709474`                                        |
 | `preview-feeds`         | Forum channel ID for preview feeds                                                   | `614877230811709474`                                        |
 | `exploit-reports-notify-channel` | Channel ID to notify when an exploit report is made                         | `614877230811709474`                                        |
+| `donation-feeds-channel` | Channel ID to in which webhook messages from Open Collective are posted             | `873968290836385792`                                        |

--- a/src/main/java/org/geysermc/discordbot/GeyserBot.java
+++ b/src/main/java/org/geysermc/discordbot/GeyserBot.java
@@ -251,6 +251,7 @@ public class GeyserBot {
                             new PreviewHandler(),
                             new AutoModHandler(),
                             new ExploitHandler(),
+                            new WebhookLinkPreviewHandler(),
                             client.build(),
                             tagClient.build())
                     .build();

--- a/src/main/java/org/geysermc/discordbot/commands/administration/SettingsCommand.java
+++ b/src/main/java/org/geysermc/discordbot/commands/administration/SettingsCommand.java
@@ -76,7 +76,9 @@ public class SettingsCommand extends SlashCommand {
                         .addChoice("RSS Feeds", "rss-feeds")
                         .addChoice("Update channel", "update-channel")
                         .addChoice("Voice Role", "voice-role")
-                        .addChoice("Exploit reports notify channel", "exploit-reports-notify-channel"),
+                        .addChoice("Exploit reports notify channel", "exploit-reports-notify-channel")
+                        .addChoice("Donation feeds channel", "donation-feeds-channel"),
+
                 new OptionData(OptionType.STRING, "value", "The value to set")
         );
     }

--- a/src/main/java/org/geysermc/discordbot/listeners/WebhookLinkPreviewHandler.java
+++ b/src/main/java/org/geysermc/discordbot/listeners/WebhookLinkPreviewHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024-2025 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/GeyserDiscordBot
+ */
+
+package org.geysermc.discordbot.listeners;
+
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.geysermc.discordbot.storage.ServerSettings;
+
+import javax.annotation.Nonnull;
+
+// Hides link previews from webhook links in certain channels
+public class WebhookLinkPreviewHandler extends ListenerAdapter {
+
+    @Override
+    public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
+        if (!event.isWebhookMessage()) return;
+        if (!event.isFromGuild()) return;
+
+        TextChannel donationFeedsChannel = ServerSettings.getDonationFeedsChannel(event.getGuild());
+        if (donationFeedsChannel == null) return;
+        if (event.getChannel().getIdLong() != donationFeedsChannel.getIdLong()) return;
+
+        // Remove embeds from the original message
+        event.getMessage().suppressEmbeds(true).queue();
+    }
+}

--- a/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
+++ b/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
@@ -107,6 +107,18 @@ public class ServerSettings {
     }
 
     /**
+     * Get the donation feeds channel for the selected guild
+     *
+     * @param guild ID of the guild to get the channel for
+     * @return The {@link TextChannel} for logs
+     * @throws IllegalArgumentException If the channel is null or invalid
+     */
+    public static TextChannel getDonationFeedsChannel(@NotNull Guild guild) throws IllegalArgumentException {
+        String channel = GeyserBot.storageManager.getServerPreference(guild.getIdLong(), "donation-feeds-channel");
+        return guild.getTextChannelById(channel);
+    }
+
+    /**
      * Get the update channel for the selected guild
      *
      * @param guild ID of the guild to get the channel for


### PR DESCRIPTION
As we can't edit the webhook content from Open Collective I thought it was best to implement it this way. I've named the listener class generically but it's only used for donation feeds channel at the moment.

I haven't been able to test as cant get the bot to run but it looks all good