### PR TITLE
Removed oudated GeyserConnect tag information

### DIFF
--- a/src/main/resources/tags/info/geyserconnect.tag
+++ b/src/main/resources/tags/info/geyserconnect.tag
@@ -6,8 +6,7 @@ aliases: gc
 There is an **Unofficial** public [GeyserConnect](https://github.com/GeyserMC/GeyserConnect) instance running. You can connect to it via
 *Addresses:* 
 United States: `us.geyserconnect.net`
-Europe: `eu.geyserconnect.net`
-Port: `19132` for both addresses.
+Port: `19132`
 
 More information is available on their [website](https://www.geyserconnect.net)
 [Xbox Users](https://www.geyserconnect.net/guide/xbox)


### PR DESCRIPTION
Removed EU address information for GeyserConnect since server is no longer online.