### PR TITLE
Revamped Roles Tags

### DIFF
--- a/src/main/resources/tags/roles/devnews.tag
+++ b/src/main/resources/tags/roles/devnews.tag
@@ -1,4 +1,6 @@
 type: text
+title: :computer: Dev News
+color: roles
 
 ---
 

--- a/src/main/resources/tags/roles/news.tag
+++ b/src/main/resources/tags/roles/news.tag
@@ -1,5 +1,7 @@
 type: text
+title: :newspaper: Geyser News
 aliases: geysernews
+color: roles
 
 ---
 

--- a/src/main/resources/tags/roles/tester.tag
+++ b/src/main/resources/tags/roles/tester.tag
@@ -1,5 +1,7 @@
 type: text
+title: :test_tube: Geyser Testers
 aliases: testers, testing
+color: roles
 
 ---
 


### PR DESCRIPTION
This PR introduces the following:

- A revamp of the current tags in the roles folder of the GeyserDiscordBot.


Requires https://github.com/GeyserMC/GeyserDiscordBot/pull/349 to be merged first.

Feel free to leave any suggestions I should implement.