### PR TITLE
Fix badge link for "Made with Java"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GeyserBot
-[![forthebadge made-with-java](https://forthebadge.com/images/badges/made-with-java.svg)](https://java.com/)
+[![forthebadge made-with-java](https://forthebadge.com/badges/made-with-java.svg)](https://java.com/)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Build Status](https://github.com/GeyserMC/GeyserDiscordBot/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/GeyserMC/GeyserDiscordBot/actions/workflows/build.yml)


### PR DESCRIPTION
I guess this changed apparently?