### PR TITLE
feat: exclude honeypot from error analyzer

### DIFF
--- a/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
+++ b/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
@@ -194,8 +194,15 @@ public class ServerSettings {
      * @return If we should exclude the channel
      */
     public static boolean shouldNotCheckError(MessageChannel channel) {
+        Guild server = getGuild(channel);
 
-        if (getGuild(channel) == null) {
+        if (server == null) {
+            return true;
+        }
+
+        // Ignore file handling in Honeypot channels
+        String honeyPotChannelId = GeyserBot.storageManager.getServerPreference(server.getIdLong(), "honey-pot-channel");
+        if (honeyPotChannelId != null && honeyPotChannelId.equals(channel.getId())) {
             return true;
         }
 


### PR DESCRIPTION
Untested, but seems like it would work fine.

Excludes OCR error checking in the honeypot channel, where messages are deleted automatically.

Ideally we exclude everything but OCR is the one causing errors, so...