### PR TITLE
Fix: use guild ID to check "dont-check-error" setting

### DIFF
--- a/src/main/java/org/geysermc/discordbot/listeners/ErrorAnalyzer.java
+++ b/src/main/java/org/geysermc/discordbot/listeners/ErrorAnalyzer.java
@@ -88,6 +88,7 @@ public class ErrorAnalyzer extends ListenerAdapter {
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
+        if (HoneyPotHandler.isHoneyPot(event.getGuild(), event.getChannel())) return;
 
         // exclude certain channels.
         if (ServerSettings.shouldNotCheckError(event.getChannel())) {

--- a/src/main/java/org/geysermc/discordbot/listeners/HoneyPotHandler.java
+++ b/src/main/java/org/geysermc/discordbot/listeners/HoneyPotHandler.java
@@ -26,7 +26,7 @@
 package org.geysermc.discordbot.listeners;
 
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.session.ReadyEvent;
@@ -34,8 +34,6 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.geysermc.discordbot.GeyserBot;
 import org.geysermc.discordbot.util.ModerationHelper;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
 
 public class HoneyPotHandler extends ListenerAdapter {
     @Override
@@ -69,11 +67,16 @@ public class HoneyPotHandler extends ListenerAdapter {
         if (event.getAuthor().isBot()) return;
         if (!event.isFromGuild()) return;
 
-        String honeyPotChannelId = GeyserBot.storageManager.getServerPreference(event.getGuild().getIdLong(), "honey-pot-channel");
-        if (honeyPotChannelId == null) return;
-
-        if (event.getChannel().getId().equals(honeyPotChannelId)) {
+        if (isHoneyPot(event.getGuild(), event.getChannel())) {
             ModerationHelper.quarantineMember(event.getMember(), event.getGuild(), "Messaged in the honey pot channel.", false, null, event.getMessage(), true);
         }
+    }
+
+    public static boolean isHoneyPot(Guild guild, Channel channel) {
+        String honeyPotChannelId = GeyserBot.storageManager.getServerPreference(guild.getIdLong(), "honey-pot-channel");
+        if (honeyPotChannelId == null) {
+            return false;
+        }
+        return channel.getId().equals(honeyPotChannelId);
     }
 }

--- a/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
+++ b/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
@@ -194,19 +194,12 @@ public class ServerSettings {
      * @return If we should exclude the channel
      */
     public static boolean shouldNotCheckError(MessageChannel channel) {
-        Guild server = getGuild(channel);
-
-        if (server == null) {
+        Guild guild = getGuild(channel);
+        if (guild == null) {
             return true;
         }
 
-        // Ignore file handling in Honeypot channels
-        String honeyPotChannelId = GeyserBot.storageManager.getServerPreference(server.getIdLong(), "honey-pot-channel");
-        if (honeyPotChannelId != null && honeyPotChannelId.equals(channel.getId())) {
-            return true;
-        }
-
-        return getList(channel.getIdLong(), "dont-check-error").contains(channel.getId());
+        return getList(guild.getIdLong(), "dont-check-error").contains(channel.getId());
     }
 
     /**

--- a/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
+++ b/src/main/java/org/geysermc/discordbot/storage/ServerSettings.java
@@ -32,7 +32,6 @@ import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.NewsChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import org.apache.commons.lang3.StringUtils;
 import org.geysermc.discordbot.GeyserBot;


### PR DESCRIPTION
This PR fixes the `dont-check-error` setting of the bot - in `ServerSettings`, the channel ID was used to query this setting, instead of the guild ID. This PR changes that to be the guild ID.